### PR TITLE
Don't track MSVC build outputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+# MSVC build output (build.cmd)
+*.exe
+*.obj
+*.res
+
+# MSVC debug/link intermediates
+*.pdb
+*.ilk
+*.idb


### PR DESCRIPTION
"build.cmd" emits "disktrim-{x64,x86,arm64}.exe" plus the intermediate "*.obj" and "*.res" files into the source
directory, so a build leaves untracked files in "git status". This adds a ".gitignore" covering those, along with the
"*.pdb", "*.ilk", and "*.idb" files a debug build adds.

Scoped to what this project actually builds, rather than the full "VisualStudio.gitignore" template.

No build artifact has ever been tracked here, so nothing already committed is affected.

https://claude.ai/code/session_01DF8XbnLy4YWkusTzkibwED
