### PR TITLE
Flush buffered output before calling "ExitProcess(...)"

### DIFF
--- a/disktrim.c
+++ b/disktrim.c
@@ -155,7 +155,7 @@ void error(int exit, WCHAR* msg, ...) {
         putchar(L'\n');
     }
 
-    FlushFileBuffers(GetStdHandle(STD_OUTPUT_HANDLE));
+    fflush(stdout);
 
     if (exit)
         ExitProcess(1);
@@ -415,7 +415,7 @@ int wmain(int argc, WCHAR* argv[]) {
 
     wprintf(L"Looks like TRIM worked!\n");
 
-    FlushFileBuffers(GetStdHandle(STD_OUTPUT_HANDLE));
+    fflush(stdout);
 
     return 0;
 }


### PR DESCRIPTION
"error(...)" flushes the OS handle with "FlushFileBuffers(GetStdHandle(STD_OUTPUT_HANDLE))" and then calls
"ExitProcess(1)".  That flushes the handle rather than the CRT's "stdout" buffer, and "ExitProcess(...)" skips CRT
cleanup, so the buffered text is discarded whenever "stdout" is not a console.

Every diagnostic on the failure path is lost as soon as output is redirected.  The process exits 1 and the log is empty:

    C:\> disktrim 1 > log.txt
    C:\> type log.txt
    C:\>

Reduced to a standalone case, "wprintf(...)" followed by "FlushFileBuffers(GetStdHandle(STD_OUTPUT_HANDLE))" and
"ExitProcess(1)" prints nothing through a pipe, while the same code using "fflush(stdout)" prints as expected.

This replaces both calls with "fflush(stdout)".

https://claude.ai/code/session_01DF8XbnLy4YWkusTzkibwED
